### PR TITLE
Check that $SILVER_SHELL env var ends with supported shell name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,11 @@ fn main() {
 
     match matches.subcommand_name().unwrap() {
         "init" => match shell.as_str() {
-            "bash" => print!("{}", include_str!("init.bash")),
-            "zsh" => print!("{}", include_str!("init.zsh")),
-            "fish" => print!("{}", include_str!("init.fish")),
-            "powershell" => print!("{}", include_str!("init.powershell")),
-            _ => panic!("unknown $SILVER_SHELL"),
+            x if x.ends_with("bash") => print!("{}", include_str!("init.bash")),
+            x if x.ends_with("zsh") => print!("{}", include_str!("init.zsh")),
+            x if x.ends_with("fish") => print!("{}", include_str!("init.fish")),
+            x if x.ends_with("powershell") => print!("{}", include_str!("init.powershell")),
+            _ => panic!("unknown $SILVER_SHELL: \"{}\". Supported shells: bash, zsh, fish, powershell", shell),
         },
         "print" => print::prompt(
             &shell,


### PR DESCRIPTION
Fixes bug that caused a panic in terminal emulators that return the full path for $0 (e.g. "/bin/bash" instead of "bash") when users set $SILVER_SHELL to $0 as instructed. Also adds a more descriptive panic message.

Closes #16