### PR TITLE
fixed cmdtime in zsh

### DIFF
--- a/src/init.zsh
+++ b/src/init.zsh
@@ -6,6 +6,6 @@ preexec() {
 }
 
 precmd() {
-	PROMPT="$(code=$? jobs=$(jobs | wc -l) cmdtime=$(($(date +%s%3N)-$SILVER_START)) silver print "${SILVER[@]}") "
 	SILVER_START=$(date +%s%3N)
+	PROMPT="$(code=$? jobs=$(jobs | wc -l) cmdtime=$(($(date +%s%3N)-$SILVER_START)) silver print "${SILVER[@]}") "
 }


### PR DESCRIPTION
In zsh the cmdtime is calculated as the time diff between preexec() and the executed job when no actual command is executed.
This led to the weird behaviour of displaying the time between prompts instead of execution time, which can be easily reproduced by just hitting enter in the prompt after some time, which then outputs the time passed since the last command (like 1h if you just press enter on an empty prompt after an hour) instead of a few ms.
Setting SILVER_START before PROMPT in precmd() fixes that.