### PR TITLE
Added right prompt support (fish and zsh)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,13 +32,13 @@ On macOS, you will have to do a bit more:
 ### Configuration
 Now that you have silver installed, you need to configure it. To have your prompt look like the one in the screenshot above, add this to your `~/.bashrc`/`~/.zshrc`:
 ```sh
-SILVER=(status:black:white dir:blue:black git:green:black cmdtime:magenta:black)
+SILVER_LEFT=(status:black:white dir:blue:black git:green:black cmdtime:magenta:black)
 export SILVER_SHELL=zsh # or bash
 ```
 
 Or add the following to your `~/.config/fish/config.fish`:
 ```fish
-set SILVER status:black:white dir:blue:black git:green:black cmdtime:magenta:black
+set SILVER_LEFT status:black:white dir:blue:black git:green:black cmdtime:magenta:black
 set -x SILVER_SHELL fish
 ```
 

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,11 +1,19 @@
 use std::env;
 
-pub fn separator() -> String {
-    env::var("SILVER_SEPARATOR").unwrap_or_else(|_| "\u{e0b0}".to_owned())
+pub fn left_separator() -> String {
+    env::var("SILVER_LEFT_SEPARATOR").unwrap_or_else(|_| "\u{e0b0}".to_owned())
 }
 
-pub fn thin_separator() -> String {
-    env::var("SILVER_THIN_SEPARATOR").unwrap_or_else(|_| "\u{e0b1}".to_owned())
+pub fn thin_left_separator() -> String {
+    env::var("SILVER_THIN_LEFT_SEPARATOR").unwrap_or_else(|_| "\u{e0b1}".to_owned())
+}
+
+pub fn right_separator() -> String {
+    env::var("SILVER_RIGHT_SEPARATOR").unwrap_or_else(|_| "\u{e0b2}".to_owned())
+}
+
+pub fn thin_right_separator() -> String {
+    env::var("SILVER_THIN_RIGHT_SEPARATOR").unwrap_or_else(|_| "\u{e0b3}".to_owned())
 }
 
 pub fn get(id: &str) -> String {

--- a/src/init.bash
+++ b/src/init.bash
@@ -1,4 +1,4 @@
 PROMPT_COMMAND=silver_prompt
 silver_prompt() {
-	PS1="$(code=$? jobs=$(jobs -p | wc -l) silver print "${SILVER[@]}") "
+	PS1="$(code=$? jobs=$(jobs -p | wc -l) silver lprint ${SILVER_LEFT[@]:-${SILVER[@]}}) "
 }

--- a/src/init.fish
+++ b/src/init.fish
@@ -1,1 +1,8 @@
-function fish_prompt; env code=$status jobs=(count (jobs -p)) cmdtime={$CMD_DURATION} silver print $SILVER; echo -n ' '; end
+function fish_prompt
+    test -n "$SILVER_LEFT"; or set SILVER_LEFT $SILVER
+    env code=$status jobs=(count (jobs -p)) cmdtime={$CMD_DURATION} silver lprint $SILVER_LEFT
+    echo -n ' '
+end
+function fish_right_prompt
+    env code=$status jobs=(count (jobs -p)) cmdtime={$CMD_DURATION} silver rprint $SILVER_RIGHT
+end

--- a/src/init.fish
+++ b/src/init.fish
@@ -1,5 +1,5 @@
 function fish_prompt
-    test -n "$SILVER_LEFT"; or set SILVER_LEFT $SILVER
+    test -n "$SILVER_LEFT"; or set -l SILVER_LEFT $SILVER
     env code=$status jobs=(count (jobs -p)) cmdtime={$CMD_DURATION} silver lprint $SILVER_LEFT
     echo -n ' '
 end

--- a/src/init.powershell
+++ b/src/init.powershell
@@ -3,6 +3,7 @@ function prompt {
     $env:code = $LASTEXITCODE
     $env:cmdtime = [uint64]($lastCommand.EndExecutionTime - $lastCommand.StartExecutionTime).TotalMilliseconds
     $env:jobs = @(Get-Job).Count
-    Start-Process -Wait -NoNewWindow silver.exe -ArgumentList (@('print') + $SILVER_LEFT)
+    Start-Process -Wait -NoNewWindow silver -ArgumentList (@('lprint') +
+    ($SILVER_LEFT ? $SILVER_LEFT : $SILVER))
     "$([char]0x1b)[0m"
 }

--- a/src/init.powershell
+++ b/src/init.powershell
@@ -3,6 +3,6 @@ function prompt {
     $env:code = $LASTEXITCODE
     $env:cmdtime = [uint64]($lastCommand.EndExecutionTime - $lastCommand.StartExecutionTime).TotalMilliseconds
     $env:jobs = @(Get-Job).Count
-    Start-Process -Wait -NoNewWindow silver.exe -ArgumentList (@('print') + $SILVER)
+    Start-Process -Wait -NoNewWindow silver.exe -ArgumentList (@('print') + $SILVER_LEFT)
     "$([char]0x1b)[0m"
 }

--- a/src/init.zsh
+++ b/src/init.zsh
@@ -2,10 +2,12 @@ SILVER_START=$(date +%s%3N)
 unsetopt prompt_subst
 
 preexec() {
-	SILVER_START=$(date +%s%3N)
+  SILVER_START=$(date +%s%3N)
 }
 
 precmd() {
-	PROMPT="$(code=$? jobs=$(jobs | wc -l) cmdtime=$(($(date +%s%3N)-$SILVER_START)) silver print "${SILVER[@]}") "
-	SILVER_START=$(date +%s%3N)
+  PROMPT="$(code=$? jobs=$(jobs | wc -l) cmdtime=$(($(date +%s%3N)-$SILVER_START)) silver lprint ${SILVER_LEFT:-$SILVER}) "
+  ZLE_RPROMPT_INDENT=0
+  RPROMPT="$(code=$? jobs=$(jobs | wc -l) cmdtime=$(($(date +%s%3N)-$SILVER_START)) silver rprint $SILVER_RIGHT)"
+  SILVER_START=$(date +%s%3N)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,21 @@ use clap::AppSettings;
 use std::env;
 use std::path::Path;
 
+#[derive(Clone, Debug)]
 pub struct Segment {
     background: String,
     foreground: String,
     value: String,
+}
+
+impl Default for Segment {
+    fn default() -> Self {
+        Self {
+            background: "none".to_owned(),
+            foreground: "none".to_owned(),
+            value: String::new(),
+        }
+    }
 }
 
 fn main() {
@@ -47,7 +58,7 @@ fn main() {
                 .arg(
                     clap::Arg::with_name("segments")
                         .required(false)
-                        .min_values(1),
+                        .min_values(0),
                 )
                 .about("Prints the left prompt with the specified modules"),
         )
@@ -73,7 +84,7 @@ fn main() {
                 shell
             ),
         },
-        "lprint" => print::left_prompt(
+        "lprint" => print::prompt(
             &shell,
             matches
                 .subcommand_matches("lprint")
@@ -86,8 +97,30 @@ fn main() {
                 .iter()
                 .map(|s| s.to_str().unwrap().to_owned())
                 .collect(),
+            |_, (_, c, n)| {
+                vec![
+                    (
+                        c.background.to_owned(),
+                        c.foreground.to_owned(),
+                        format!(" {} ", c.value),
+                    ),
+                    if n.background == c.background {
+                        (
+                            c.background.to_owned(),
+                            c.foreground.to_owned(),
+                            icons::thin_left_separator(),
+                        )
+                    } else {
+                        (
+                            n.background.to_owned(),
+                            c.background.to_owned(),
+                            icons::left_separator(),
+                        )
+                    },
+                ]
+            },
         ),
-        "rprint" => print::right_prompt(
+        "rprint" => print::prompt(
             &shell,
             matches
                 .subcommand_matches("rprint")
@@ -100,6 +133,28 @@ fn main() {
                 .iter()
                 .map(|s| s.to_str().unwrap().to_owned())
                 .collect(),
+            |_, (p, c, _)| {
+                vec![
+                    if p.background == c.background {
+                        (
+                            c.background.to_owned(),
+                            c.foreground.to_owned(),
+                            icons::thin_right_separator(),
+                        )
+                    } else {
+                        (
+                            p.background.to_owned(),
+                            c.background.to_owned(),
+                            icons::right_separator(),
+                        )
+                    },
+                    (
+                        c.background.to_owned(),
+                        c.foreground.to_owned(),
+                        format!(" {} ", c.value),
+                    ),
+                ]
+            },
         ),
         _ => panic!(),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,22 @@ fn main() {
             clap::SubCommand::with_name("init").about("Initializes the shell for use of silver"),
         )
         .subcommand(
-            clap::SubCommand::with_name("print")
+            clap::SubCommand::with_name("lprint")
                 .arg(
                     clap::Arg::with_name("segments")
-                        .required(true)
+                        .required(false)
                         .min_values(1),
                 )
-                .about("Prints the prompt with the specified modules"),
+                .about("Prints the left prompt with the specified modules"),
+        )
+        .subcommand(
+            clap::SubCommand::with_name("rprint")
+                .arg(
+                    clap::Arg::with_name("segments")
+                        .required(false)
+                        .min_values(0),
+                )
+                .about("Prints the right prompt with the specified modules"),
         )
         .get_matches();
 
@@ -64,14 +73,33 @@ fn main() {
                 shell
             ),
         },
-        "print" => print::prompt(
+        "lprint" => print::left_prompt(
             &shell,
-            matches.subcommand_matches("print").unwrap().args["segments"]
-                .vals
+            matches
+                .subcommand_matches("lprint")
+                .unwrap()
+                .args
+                .get("segments")
+                .map(|v| &v.vals)
+                .unwrap_or(&vec![])
                 // converts OsStrs to Strings, which are Sized
                 .iter()
                 .map(|s| s.to_str().unwrap().to_owned())
-                .collect::<Vec<String>>(),
+                .collect(),
+        ),
+        "rprint" => print::right_prompt(
+            &shell,
+            matches
+                .subcommand_matches("rprint")
+                .unwrap()
+                .args
+                .get("segments")
+                .map(|v| &v.vals)
+                .unwrap_or(&vec![])
+                // converts OsStrs to Strings, which are Sized
+                .iter()
+                .map(|s| s.to_str().unwrap().to_owned())
+                .collect(),
         ),
         _ => panic!(),
     }

--- a/src/modules/dir.rs
+++ b/src/modules/dir.rs
@@ -7,9 +7,7 @@ use Segment;
 pub fn segment(segment: &mut Segment, _: &[&str]) {
     let mut wd = match env::current_dir() {
         Ok(wd) => wd,
-        Err(_) => {
-            return
-        }
+        Err(_) => return,
     };
 
     // processes aliases

--- a/src/modules/git.rs
+++ b/src/modules/git.rs
@@ -62,11 +62,7 @@ pub fn segment(segment: &mut Segment, args: &[&str]) {
         {
             for status in statuses.iter() {
                 // dirty
-                segment.background = if args.is_empty() {
-                    "yellow"
-                } else {
-                    args[0]
-                }.to_owned();
+                segment.background = if args.is_empty() { "yellow" } else { args[0] }.to_owned();
 
                 let status = status.status();
                 if modified.is_empty() && status.is_wt_new()

--- a/src/modules/toolbox.rs
+++ b/src/modules/toolbox.rs
@@ -1,9 +1,9 @@
-use Segment;
 use icons;
 use std::env;
+use Segment;
 
 pub fn segment(segment: &mut Segment, _: &[&str]) {
-    if let Err(_) = env::var("TOOLBOX_PATH") {
+    if env::var("TOOLBOX_PATH").is_err() {
         return;
     }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -3,7 +3,7 @@ use modules;
 use sh;
 use Segment;
 
-pub fn prompt(shell: &str, args: Vec<String>) {
+pub fn left_prompt(shell: &str, args: Vec<String>) {
     let mut segments = vec![];
     for arg in args {
         let fields = arg.split(':').collect::<Vec<&str>>();
@@ -38,14 +38,14 @@ pub fn prompt(shell: &str, args: Vec<String>) {
                     &shell,
                     &segment.background,
                     &last_segment.foreground,
-                    &icons::thin_separator(),
+                    &icons::thin_left_separator(),
                 );
             } else {
                 print_segment(
                     &shell,
                     &segment.background,
                     &last_segment.background,
-                    &icons::separator(),
+                    &icons::left_separator(),
                 );
             }
         }
@@ -65,8 +65,61 @@ pub fn prompt(shell: &str, args: Vec<String>) {
         &shell,
         "none",
         &last_segment.background,
-        &icons::separator(),
+        &icons::left_separator(),
     );
+    sh::reset_colors(&shell);
+}
+
+pub fn right_prompt(shell: &str, args: Vec<String>) {
+    let segments = args
+        .iter()
+        .map(|arg| {
+            let fields: Vec<_> = arg.split(':').collect();
+            if fields.len() < 3 {
+                panic!("invalid argument, {}", arg);
+            }
+
+            let mut segment = Segment {
+                background: fields[1].to_owned(),
+                foreground: fields[2].to_owned(),
+                value: "".to_owned(),
+            };
+            modules::handle(fields[0], &mut segment, &fields[3..]);
+            segment
+        })
+        .filter(|seg| !seg.value.is_empty());
+
+    let mut last_segment = Segment {
+        background: "none".to_owned(),
+        foreground: "none".to_owned(),
+        value: String::new(),
+    };
+    for segment in segments {
+        if segment.background == last_segment.background {
+            print_segment(
+                &shell,
+                &segment.background,
+                &last_segment.foreground,
+                &icons::thin_right_separator(),
+            );
+        } else {
+            print_segment(
+                &shell,
+                &last_segment.background,
+                &segment.background,
+                &icons::right_separator(),
+            );
+        }
+
+        print_segment(
+            &shell,
+            &segment.background,
+            &segment.foreground,
+            &format!(" {} ", segment.value),
+        );
+        last_segment = segment;
+    }
+
     sh::reset_colors(&shell);
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,133 +1,45 @@
-use icons;
 use modules;
 use sh;
+use std::iter::once;
 use Segment;
 
-pub fn left_prompt(shell: &str, args: Vec<String>) {
-    let mut segments = vec![];
-    for arg in args {
-        let fields = arg.split(':').collect::<Vec<&str>>();
-        if fields.len() < 3 {
-            panic!("invalid argument, {}", arg);
-        }
+pub fn prompt<T, U>(shell: &str, args: Vec<String>, f: T)
+where
+    T: Fn(usize, (&Segment, &Segment, &Segment)) -> U,
+    U: IntoIterator<Item = (String, String, String)>,
+{
+    let v: Vec<_> = once(Segment::default())
+        .chain(
+            args.into_iter()
+                .map(|arg| {
+                    let fields: Vec<_> = arg.split(':').collect();
+                    if fields.len() < 3 {
+                        panic!("invalid argument, {}", arg);
+                    }
 
-        let mut segment = Segment {
-            background: fields[1].to_owned(),
-            foreground: fields[2].to_owned(),
-            value: "".to_owned(),
-        };
-        modules::handle(fields[0], &mut segment, &fields[3..]);
-        segments.push(segment);
-    }
+                    let mut segment = Segment {
+                        background: fields[1].to_owned(),
+                        foreground: fields[2].to_owned(),
+                        ..Default::default()
+                    };
+                    modules::handle(fields[0], &mut segment, &fields[3..]);
+                    segment
+                })
+                .filter(|seg| !seg.value.is_empty()),
+        )
+        .chain(once(Segment::default()))
+        .collect();
 
-    let mut first = true;
-    let mut last_segment = Segment {
-        background: "black".to_owned(),
-        foreground: "white".to_owned(),
-        value: String::new(),
-    };
-    for segment in segments {
-        if segment.value.is_empty() {
-            continue;
-        }
-
-        // if this isn't the first segment, before printing the next segment, separate them
-        if !first {
-            if segment.background == last_segment.background {
-                print_segment(
-                    &shell,
-                    &segment.background,
-                    &last_segment.foreground,
-                    &icons::thin_left_separator(),
-                );
-            } else {
-                print_segment(
-                    &shell,
-                    &segment.background,
-                    &last_segment.background,
-                    &icons::left_separator(),
-                );
-            }
-        }
-        first = false;
-
-        print_segment(
-            &shell,
-            &segment.background,
-            &segment.foreground,
-            &format!(" {} ", segment.value),
-        );
-        last_segment = segment;
-    }
-
-    // prints final separator
-    print_segment(
-        &shell,
-        "none",
-        &last_segment.background,
-        &icons::left_separator(),
-    );
-    sh::reset_colors(&shell);
-}
-
-pub fn right_prompt(shell: &str, args: Vec<String>) {
-    let segments = args
-        .iter()
-        .map(|arg| {
-            let fields: Vec<_> = arg.split(':').collect();
-            if fields.len() < 3 {
-                panic!("invalid argument, {}", arg);
-            }
-
-            let mut segment = Segment {
-                background: fields[1].to_owned(),
-                foreground: fields[2].to_owned(),
-                value: "".to_owned(),
-            };
-            modules::handle(fields[0], &mut segment, &fields[3..]);
-            segment
-        })
-        .filter(|seg| !seg.value.is_empty());
-
-    let mut last_segment = Segment {
-        background: "none".to_owned(),
-        foreground: "none".to_owned(),
-        value: String::new(),
-    };
-    for segment in segments {
-        if segment.background == last_segment.background {
-            print_segment(
-                &shell,
-                &segment.background,
-                &last_segment.foreground,
-                &icons::thin_right_separator(),
+    let n = v.len() - 2;
+    (0..n)
+        .flat_map(|i| f(i, (&v[i], &v[i + 1], &v[i + 2])))
+        .for_each(|(bg, fg, val)| {
+            print!(
+                "{}{}{}",
+                sh::escape_background(shell, &bg),
+                sh::escape_foreground(shell, &fg),
+                val,
             );
-        } else {
-            print_segment(
-                &shell,
-                &last_segment.background,
-                &segment.background,
-                &icons::right_separator(),
-            );
-        }
-
-        print_segment(
-            &shell,
-            &segment.background,
-            &segment.foreground,
-            &format!(" {} ", segment.value),
-        );
-        last_segment = segment;
-    }
-
-    sh::reset_colors(&shell);
-}
-
-fn print_segment(shell: &str, background: &str, foreground: &str, value: &str) {
-    print!(
-        "{}{}{}",
-        sh::escape_background(shell, background),
-        sh::escape_foreground(shell, foreground),
-        value
-    );
+        });
+    sh::reset_colors(shell);
 }

--- a/src/sh.rs
+++ b/src/sh.rs
@@ -54,7 +54,7 @@ pub fn escape_background(shell: &str, color: &str) -> String {
             if HEX.is_match(&color) {
                 format!("%{{\x1b[48;2;{}m%}}", escape_hex(color))
             } else if color == "none" {
-                format!("%k")
+                "%k".to_string()
             } else {
                 format!("%K{{{}}}", color)
             }


### PR DESCRIPTION
Closes #23.
Changed `$SILVER` to `$SILVER_LEFT`, `$SILVER_SEPARATOR` to `$SILVER_LEFT_SEPARATOR` etc., also `silver print` is now `silver lprint`
For bash, zsh and fish edited init files for backwards compatibility (needs also powershell).
Also prompts can be empty now

## TODO:
* [x] Edit powershell script to get backwards support
  * [x] Check Windows support
* [x] Refactor to remove code duplicated in print functions
* [ ] Update [`readme.md`](https://github.com/reujab/silver/blob/master/readme.md)
  * [x] Change variables to the new ones
  * [ ] Include information about right prompt
* [ ] Update wiki
* [ ] Update [`Cargo.toml`](https://github.com/reujab/silver/blob/master/Cargo.toml)