### PR TITLE
update to work better on windows with pwsh

### DIFF
--- a/src/init.ps1
+++ b/src/init.ps1
@@ -3,7 +3,7 @@ function prompt {
     $env:code = $LASTEXITCODE
     $env:cmdtime = [uint64]($lastCommand.EndExecutionTime - $lastCommand.StartExecutionTime).TotalMilliseconds
     $env:jobs = @(Get-Job).Count
-    Start-Process -Wait -NoNewWindow silver lprint
+    Start-Process -Wait -NoNewWindow -FilePath silver
     "$([char]0x1b)[0m"
 }
 $Env:VIRTUAL_ENV_DISABLE_PROMPT = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
             .replace(
                 "silver",
                 format!(
-                    "silver.exe {}",
+                    "silver {}",
                     if let Some(path) = CONFIG_PATH.get() {
                         let path_canon = path.canonicalize().expect("invalid path");
                         format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ static CONFIG: Lazy<config::Config> = Lazy::new(|| {
 pub struct Segment {
     background: String,
     foreground: String,
-    value:      String,
+    value: String,
 }
 
 impl Default for Segment {
@@ -33,7 +33,7 @@ impl Default for Segment {
         Self {
             background: "none".to_owned(),
             foreground: "none".to_owned(),
-            value:      String::new(),
+            value: String::new(),
         }
     }
 }
@@ -43,42 +43,42 @@ fn main() {
     let process = sys.get_process(get_current_pid().unwrap()).unwrap();
     let parent = sys.get_process(process.parent().unwrap()).unwrap();
     let shell = parent.name().trim();
-
     let opt = cli::Silver::from_args();
-
     if let Some(path) = opt.config {
         let path = Path::new(path.as_str()).canonicalize().unwrap();
         CONFIG_PATH.set(path).unwrap()
     }
 
     match opt.cmd {
-        Command::Init => {
-            print!(
-                "{}",
-                match shell {
-                    "bash" => include_str!("init.bash"),
-                    "powershell" | "pwsh" => include_str!("init.ps1"),
-                    "ion" => include_str!("init.ion"),
-                    _ =>
-                        panic!(
-                            "unknown shell: \"{}\". Supported shells: bash, ion, powershell",
-                            shell
-                        ),
-                }
-                .replace(
-                    "silver",
-                    format!(
-                        "silver{}",
-                        if let Some(path) = CONFIG_PATH.get() {
-                            format!(" --config {}", path.display())
-                        } else {
-                            String::new()
-                        }
-                    )
-                    .as_str()
+        Command::Init => print!(
+            "{}",
+            match shell {
+                "bash" => include_str!("init.bash"),
+                "powershell" | "pwsh" | "powershell.exe" | "pwsh.exe" => include_str!("init.ps1"),
+                // "codelldb.exe" => include_str!("init.ps1"), //only used when debugging with codelldb on windows
+                "ion" => include_str!("init.ion"),
+                _ => panic!(
+                    "unknown shell: \"{}\". Supported shells: bash, ion, powershell",
+                    shell
+                ),
+            }
+            .replace(
+                "silver",
+                format!(
+                    "silver.exe {}",
+                    if let Some(path) = CONFIG_PATH.get() {
+                        let path_canon = path.canonicalize().expect("invalid path");
+                        format!(
+                            "-ArgumentList @('--config','{}','lprint')",
+                            adjust_canonicalization(path_canon)
+                        )
+                    } else {
+                        "-ArgumentList @('lprint')".to_string()
+                    }
                 )
+                .as_str()
             )
-        }
+        ),
         Command::Lprint => {
             print::prompt(&shell, &CONFIG.left, |_, (_, c, n)| {
                 vec![
@@ -105,29 +105,43 @@ fn main() {
             print!(" ")
         }
 
-        Command::Rprint => {
-            print::prompt(&shell, &CONFIG.right, |_, (p, c, _)| {
-                vec![
-                    if p.background == c.background {
-                        (
-                            c.background.to_owned(),
-                            c.foreground.to_owned(),
-                            CONFIG.separator.right.thin.to_owned(),
-                        )
-                    } else {
-                        (
-                            p.background.to_owned(),
-                            c.background.to_owned(),
-                            CONFIG.separator.right.thick.to_owned(),
-                        )
-                    },
+        Command::Rprint => print::prompt(&shell, &CONFIG.right, |_, (p, c, _)| {
+            vec![
+                if p.background == c.background {
                     (
                         c.background.to_owned(),
                         c.foreground.to_owned(),
-                        format!(" {} ", c.value),
-                    ),
-                ]
-            })
-        }
+                        CONFIG.separator.right.thin.to_owned(),
+                    )
+                } else {
+                    (
+                        p.background.to_owned(),
+                        c.background.to_owned(),
+                        CONFIG.separator.right.thick.to_owned(),
+                    )
+                },
+                (
+                    c.background.to_owned(),
+                    c.foreground.to_owned(),
+                    format!(" {} ", c.value),
+                ),
+            ]
+        }),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    p.as_ref().display().to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    const VERBATIM_PREFIX: &str = r#"\\?\"#;
+    let p = p.as_ref().display().to_string();
+    if p.starts_with(VERBATIM_PREFIX) {
+        p[VERBATIM_PREFIX.len()..].to_string()
+    } else {
+        p
     }
 }


### PR DESCRIPTION
The key to using powershell is making sure that when we use `Start-Process` make sure we give it an `-ArgumentList` otherwise the parameters won't work right. Another thing I had to change is when getting the path of the config file, we need to canonicalize it and then remove the `\\?\` on windows.
The last thing I added, that is now commented out is to allow `codelldb.exe` to be used as a shell in order to debug what's going on in the program without littering the code with println!()'s.