### PR TITLE
Add full path to silver.toml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ On macOS, you will have to do a bit more:
 
 ### Configuration
 
-Now that you have silver installed, you need to configure it. To have your prompt look like the one in the screenshot above, create `silver.toml` with the following content:
+Now that you have silver installed, you need to configure it. To have your prompt look like the one in the screenshot above, create `~/.config/silver/silver.toml` with the following content:
 
 ```toml
 [[left]]


### PR DESCRIPTION
For new users and users migrating <2.0 it may be a bit confusing, why the prompt is just "invisible". So showing the full path to the config may help, without the need to read the wiki pages.