### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -20,26 +20,26 @@ fn is_root() -> bool {
 
     let mut token = INVALID_HANDLE_VALUE;
     let mut elevated = false;
-    unsafe {
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == TRUE {
-            let mut elevation: TOKEN_ELEVATION = mem::zeroed();
+    
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == TRUE } {
+            let mut elevation: TOKEN_ELEVATION = unsafe { mem::zeroed() };
             let mut size = mem::size_of::<TOKEN_ELEVATION>() as DWORD;
-            if GetTokenInformation(
+            if unsafe { GetTokenInformation(
                 token,
                 TokenElevation,
                 &mut elevation as *mut TOKEN_ELEVATION as *mut c_void,
                 size,
                 &mut size,
-            ) == TRUE
+            ) == TRUE }
             {
                 elevated = elevation.TokenIsElevated != 0;
             }
         }
 
         if token != INVALID_HANDLE_VALUE {
-            CloseHandle(token);
+            unsafe { CloseHandle(token) };
         }
-    }
+    
 
     elevated
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html