### PR TITLE
Allow any case of Hex for Color, instead of lowercase only

### DIFF
--- a/src/sh.rs
+++ b/src/sh.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 lazy_static! {
     // global regex constant
-    static ref HEX: Regex = Regex::new(r"^[a-f\d]{6}$").unwrap();
+    static ref HEX: Regex = Regex::new(r"^[a-fA-F\d]{6}$").unwrap();
 }
 
 fn code(color: &str, prefix: &str, light_prefix: &str) -> Option<String> {


### PR DESCRIPTION
The error for hex color with uppercase is confusing and I think the configuration should not be that pedantic.
So I expanded the regex to also allow uppercase hex for colors.